### PR TITLE
Deploy: use external Neon PostgreSQL on Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Le projet inclut un fichier `render.yaml` permettant le déploiement automatique
 
 ### Prérequis
 
-- Un compte [Render](https://render.com) (l'offre gratuite suffit)
+- Un compte [Render](https://render.com)
+- Une base PostgreSQL [Neon](https://neon.tech)
 - Le dépôt forké ou connecté à votre compte GitHub
 
 ### Étapes
@@ -47,8 +48,13 @@ Le projet inclut un fichier `render.yaml` permettant le déploiement automatique
 3. Render détecte automatiquement le fichier `render.yaml` et crée les deux services :
    - **dictee-backend** — API Spring Boot (Docker, port 8080, profil `prod`)
    - **dictee-frontend** — site statique Vue/Vite
-4. Les variables d'environnement (`VITE_API_URL`, `CORS_ALLOWED_ORIGINS`, `SPRING_PROFILES_ACTIVE`) sont configurées automatiquement entre les deux services.
-5. Cliquez sur **Apply** pour lancer le déploiement.
+4. Créez votre base PostgreSQL sur Neon puis récupérez :
+    - `DATABASE_URL` (URL de connexion)
+    - `DATABASE_USERNAME`
+    - `DATABASE_PASSWORD`
+5. Dans Render, ouvrez le service **dictee-backend** puis renseignez ces 3 variables d'environnement.
+6. Les variables d'environnement (`VITE_API_URL`, `CORS_ALLOWED_ORIGINS`, `SPRING_PROFILES_ACTIVE`) sont configurées automatiquement entre les deux services.
+7. Cliquez sur **Apply** pour lancer le déploiement.
 
 > **Note :** Sur l'offre gratuite, les services s'endorment après 15 minutes d'inactivité. Le premier appel après une période d'inactivité peut prendre quelques secondes.
 

--- a/render.yaml
+++ b/render.yaml
@@ -12,17 +12,11 @@ services:
       - key: CORS_ALLOWED_ORIGINS
         value: https://dictee-frontend.onrender.com
       - key: DATABASE_URL
-        fromDatabase:
-          name: dictee-db
-          property: jdbcConnectionString
+        sync: false
       - key: DATABASE_USERNAME
-        fromDatabase:
-          name: dictee-db
-          property: user
+        sync: false
       - key: DATABASE_PASSWORD
-        fromDatabase:
-          name: dictee-db
-          property: password
+        sync: false
 
   # Frontend — Vue/Vite (site statique)
   - type: web
@@ -34,7 +28,3 @@ services:
     envVars:
       - key: VITE_API_URL
         value: https://dictee-backend.onrender.com
-
-databases:
-  - name: dictee-db
-    plan: free


### PR DESCRIPTION
## Summary
- remove Render managed database from blueprint
- switch backend DB env vars to manual values (`DATABASE_URL`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`)
- update deployment documentation to use Neon PostgreSQL

## Why
Render free database is no longer available for this project.

## Impact
- deployment now requires creating a Neon PostgreSQL database
- backend environment variables must be set in Render before deploy

## Files changed
- README.md
- render.yaml